### PR TITLE
Avoid collisions with middleman-deploy gem

### DIFF
--- a/lib/middleman-email/commands.rb
+++ b/lib/middleman-email/commands.rb
@@ -98,7 +98,7 @@ module Middleman
         options = nil
 
         begin
-          options = app.options
+          options = app.email_options
         rescue NoMethodError
           raise Error, "ERROR: ou need to activate the email extension in config.rb.\n#{Middleman::Email::README}"
         end

--- a/lib/middleman-email/extension.rb
+++ b/lib/middleman-email/extension.rb
@@ -53,7 +53,7 @@ module Middleman
 
 
     module Helpers
-      def options
+      def email_options
         ::Middleman::Email.options
       end
     end


### PR DESCRIPTION
The options method was declared as a helper that was being
included in the app instance. Middleman Deploy does the same,
and the middleman-email extension was overriding the middleman
deploy options.

In the future we need to rewrite the extension using the extension format used by other gems
like middleman-autoprefixer, which is safer.
